### PR TITLE
added vcfFields-VcfStack-method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description: This package provides infrastructure for parallel
 	computations distributed 'by file' or 'by range'. User 
 	defined MAPPER and REDUCER functions provide added 
 	flexibility for data combination and manipulation.
-Version: 1.17.2
+Version: 1.17.3
 Authors@R: c(person("Bioconductor Package Maintainer", role = c("aut", "cre"),
 		     email = "maintainer@bioconductor.org"),
 	      person("Valerie", "Obenchain", role = "aut"),
@@ -16,7 +16,7 @@ Depends: R (>= 3.1.0), methods, BiocGenerics (>= 0.11.2),
         GenomicRanges (>= 1.31.16), SummarizedExperiment,
         BiocParallel (>= 1.1.0), Rsamtools (>= 1.17.29), rtracklayer (>= 1.25.3)
 Imports: GenomicAlignments (>= 1.7.7), IRanges, S4Vectors (>= 0.9.25),
-        VariantAnnotation, GenomeInfoDb
+        VariantAnnotation (>= 1.27.6), GenomeInfoDb
 Suggests: BiocStyle, RUnit, genefilter, deepSNV,
 	RNAseqData.HNRNPC.bam.chr14, Biostrings, Homo.sapiens
 License: Artistic-2.0
@@ -32,4 +32,4 @@ Collate: GenomicFiles-class.R
 	registry.R
 	zzz.R
 Video: https://www.youtube.com/watch?v=3PK_jx44QTs
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -31,7 +31,8 @@ exportMethods(
     countBam, scanBam, summarizeOverlaps,
     coverage, summary,
     seqinfo, 'seqinfo<-',
-    rowRanges, 'rowRanges<-', assay, colData
+    rowRanges, 'rowRanges<-', assay, colData,
+    vcfFields
 )
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+CHANGES IN VERSION 1.17.3
+------------------------
+
+NEW FEATURES
+
+    o Add vcfFields,VcfStack-method.
+
+
 CHANGES IN VERSION 1.6.0
 ------------------------
 

--- a/R/VcfStack-class.R
+++ b/R/VcfStack-class.R
@@ -255,6 +255,16 @@ setReplaceMethod("rowRanges", c("RangedVcfStack", "GRanges"),
 ### Other methods
 ###
 
+setMethod("vcfFields", "VcfStack", function(x, ...)
+{
+    if (length(files(x))) {
+        stop("The input \"VcfStack\" object has 0 file.")
+    } else {
+        vcf <- files(x)[[1]]
+        vcfFields(vcf)
+    }
+})
+
 setMethod("assay", c("VcfStack", "ANY"),
      function(x, i, ..., BPPARAM=bpparam())
 {

--- a/inst/unitTests/test_VcfStack-class.R
+++ b/inst/unitTests/test_VcfStack-class.R
@@ -224,3 +224,19 @@ test_VcfStack_readVcfStack <- function(){
     temp7 = readVcfStack(Rstack)
     checkTrue(all(dim(temp7) == dim(temp5)))
 }
+
+test_VcfStack_vcfFields <- function(){
+
+    ## empty
+    checkException(vcfFields(VcfStack()), silent=TRUE)
+
+    ## names
+    stack <- VcfStack(files)
+    flds <- vcfFields(stack)
+    checkTrue(is(flds, "CharacterList"))
+    checkIdentical(names(flds), c("fixed", "info", "geno", "samples"))
+    
+    fl <- files(stack)[[1]]
+    flds.fl <- vcfFields(fl)
+    checkIdentical(flds, flds.fl)
+}

--- a/man/VcfStack-class.Rd
+++ b/man/VcfStack-class.Rd
@@ -31,6 +31,7 @@
 \alias{rowRanges<-,RangedVcfStack,GRanges-method}
 
 % Methods:
+\alias{vcfFields,VcfStack-method}
 \alias{assay,VcfStack,ANY-method}
 \alias{assay,RangedVcfStack,ANY-method}
 \alias{readVcfStack}
@@ -157,6 +158,13 @@
   RangedVcfStack object, assay and readVcfStack will use the associated
   \code{rowRanges} object for \code{i}.
   \describe{
+    \item{vcfFields(x)}{
+      Returns a \code{\link[IRanges]{CharacterList}} of all
+      available VCF fields, with names of \code{fixed}, \code{info},
+      \code{geno} and \code{samples} indicating the four categories.
+      Each element is a character() vector of available VCF field
+      names within each category.
+    }
     \item{assay(x, i, \dots, BPPARAM=bpparam())}{
       Get matrix of genotype calls from the VCF files.
       See \link[VariantAnnotation]{genotypeToSnpMatrix}. Argument \code{i}
@@ -275,6 +283,7 @@ seqlevelsStyle(stack2) <- "UCSC"
 seqlevelsStyle(stack2)
 seqlevels(stack2)
 rownames(stack2)
+vcfFields(stack2)
 
 ## ---------------------------------------------------------------------
 ## SUBSETTING


### PR DESCRIPTION
In accordance with the newly added generic and method of `vcfFields` in `VariantAnnotation` (see [here](https://github.com/Bioconductor/VariantAnnotation/commit/b36cfa524ca13135c9f00bafb541be75ed391707)), Here I am adding the same method for `VcfStack` objects. 

Updates includes adding method, documentation, runnable example, NEWS (new feature), NAMESPACE (export), and DESCRIPTION (version bump, Imports: VariantAnnotation >= 1.27.5). 

Could pass `R CMD check` successfully. 