### PR TITLE
fix: readVcfStack(param=ScanVcfParam()) reads all files when which= is empty (#50)

### DIFF
--- a/R/VcfStack-class.R
+++ b/R/VcfStack-class.R
@@ -313,7 +313,12 @@ readVcfStack <- function(x, i, j=colnames(x), param=ScanVcfParam())
         gr <- GRanges()
     } else {                            # use param
         gr <- GRanges(vcfWhich(param))
-        i = intersect(names(files(x)), as.character(seqnames(gr)))
+        if (length(gr)) {
+            i = intersect(names(files(x)), as.character(seqnames(gr)))
+        } else {
+            ## param provided but no which= specified: read all files
+            i = names(files(x))
+        }
     }
     x = x[i]
 

--- a/inst/unitTests/test_VcfStack-class.R
+++ b/inst/unitTests/test_VcfStack-class.R
@@ -223,6 +223,14 @@ test_VcfStack_readVcfStack <- function(){
     Rstack = RangedVcfStack(stack, gr)
     temp7 = readVcfStack(Rstack)
     checkTrue(all(dim(temp7) == dim(temp5)))
+
+    # test param=ScanVcfParam() with no which= reads all variants (#50)
+    # Previously returned 0-row VCF because empty which= intersected to empty i
+    tempParam = readVcfStack(Rstack, param=ScanVcfParam())
+    checkTrue(all(dim(tempParam) == dim(temp7)))
+
+    tempParamStack = readVcfStack(stack, param=ScanVcfParam())
+    checkTrue(all(dim(tempParamStack) == dim(temp)))
 }
 
 test_VcfStack_vcfFields <- function(){


### PR DESCRIPTION
## Problem

When `param` is provided but `which=` is not specified (e.g. `param=ScanVcfParam()`), `readVcfStack()` silently returned a 0-row VCF.

Root cause: in the `else { # use param }` branch, `gr <- GRanges(vcfWhich(param))` produces an empty `GRanges`, and `i = intersect(names(files(x)), as.character(seqnames(gr)))` then evaluates to `character(0)` — so `x = x[i]` produces an empty stack and nothing is read.

This is inconsistent with both:
- `readVcfStack(rstack)` (no param) which reads everything
- `readVcf(vf, genome, param=ScanVcfParam())` which correctly reads all variants

## Fix

In `R/VcfStack-class.R`, when `param` is provided but `gr` is empty, fall back to `i = names(files(x))` so all files are read — matching the documented behaviour of `ScanVcfParam()` where an unspecified `which=` means "return all ranges".

## Test

Added two checks to `inst/unitTests/test_VcfStack-class.R`:
- `readVcfStack(Rstack, param=ScanVcfParam())` returns same dims as `readVcfStack(Rstack)`
- `readVcfStack(stack, param=ScanVcfParam())` returns same dims as `readVcfStack(stack)`

Fixes #50